### PR TITLE
Removed .env from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@
 **/.vscode
 **/npm-debug.log
 **/coverage
-**/.env
 **/.editorconfig
 **/dist
 **/*.pem


### PR DESCRIPTION
This PR removes the `.env` file from `.dockerignore` so we can use the `.env` configuration on the production server.