### PR TITLE
Removed *.pem from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,4 @@
 **/coverage
 **/.editorconfig
 **/dist
-**/*.pem
 Dockerfile


### PR DESCRIPTION
Remove the *.pem files in dockerignore so they can be used in Docker