### PR TITLE
Comment the review checklist only on vitessio/vitess

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,12 @@ module.exports = (app) => {
 
   app.on(["pull_request.opened", "pull_request.ready_for_review", "pull_request.reopened"], async (context) => {
     const pr = context.pullRequest();
+
+    // We only comment when the repository if vitessio/vitess
+    if (pr.owner != 'vitessio' && pr.repo != 'vitess') {
+      return
+    }
+
     let comments = await context.octokit.rest.issues.listComments({
       owner: pr.owner,
       repo: pr.repo,


### PR DESCRIPTION
## Description

This Pull Request changes the review checklist action. We now only comment on the `vitessio/vitess` repository. This is done to avoid other repositories where the app is installed to have the review checklist commented on every Pull Request.