### PR TITLE
Automatic documentation for vitess error code

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,9 +116,10 @@ module.exports = (app) => {
     let output = execSync("cd /tmp/vitess && go run ./go/vt/vterrors/main/");
     let errStrVitess = output.toString()
 
+    const docPath = "/tmp/website/content/en/docs/15.0/reference/errors/query-serving.md"
     execSync("git clone https://github.com/vitessio/website /tmp/website || true");
     execSync("cd /tmp/website");
-    output = execSync("cd /tmp/website && git fetch && cat /tmp/website/content/en/docs/15.0/reference/errors/query-serving.md");
+    output = execSync("cd /tmp/website && git fetch && cat " + docPath);
     let errStrWebsite = output.toString()
 
     const prefixLabel = "<!-- start -->"
@@ -130,7 +131,7 @@ module.exports = (app) => {
 
     let str = prefix + '\n' + errStrVitess + suffix
 
-    fs.writeFileSync('/tmp/website/content/en/docs/15.0/reference/errors/query-serving.md', str);
+    fs.writeFileSync(docPath, str);
     output = execSync("cd /tmp/website && git status -s");
     if (output.toString().length == 0) {
       return

--- a/index.js
+++ b/index.js
@@ -198,6 +198,7 @@ module.exports = (app) => {
       repo: "website",
       ref: "heads/" + branchName,
       sha: createCommit.data.sha,
+      force: true,
     });
 
     if (newBranch) {


### PR DESCRIPTION
This Pull Request adds a new endpoint to the bot that auto-documents the query serving the error codes of Vitess.

Each time a pull request is opened or synchronized, the bot will go through the list of modified files for this Pull Request and search if `go/vt/vterrors/code.go` (the file that lists all the error codes) has been modified.

If it is, we will generate the README version of the error codes (using the new code in https://github.com/vitessio/vitess/pull/10738).

We then determine if the new README is different than the one on the main branch of the docs repository. If the content of `content/en/docs/15.0/reference/errors/query-serving.md` that is in between the two new tags `<!-- start -->` and `<!-- end -->`. Those tags were added to the docs in this Pull Request: https://github.com/vitessio/website/pull/1100. They define the boundary of the auto-generated docs.

If the content is different, we then try to get the branch that will be used to add the new docs, the format is: `update-error-code-{vitessio/vitess' pull number}`. If no branch exist, we create it. We then create a commit with the new documentation, push it to the branch, and create a Pull Request if needed.