### PR TITLE
Fix the review checklist repo/owner pre-condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = (app) => {
     const pr = context.pullRequest();
 
     // We only comment when the repository if vitessio/vitess
-    if (pr.owner != 'vitessio' && pr.repo != 'vitess') {
+    if (pr.owner !== "vitessio" || pr.repo !== "vitess") {
       return
     }
 
@@ -91,7 +91,7 @@ module.exports = (app) => {
 
     for (let index = 0; index < comments.data.length; index++) {
       const element = comments.data[index];
-      if (element.user.login == "vitess-bot[bot]" && element.body.includes("### Review Checklist")) {
+      if (element.user.login === "vitess-bot[bot]" && element.body.includes("### Review Checklist")) {
         comment.comment_id = element.id;
         return context.octokit.issues.updateComment(comment);
       }


### PR DESCRIPTION
This Pull Request fixes the condition to restrict the scope of the review checklist comment. It was previously commenting on any `vitessio` repository, it now comments only on `vitessio/vitess`.