### PR TITLE
Use node 19 and buster Docker image and install Go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,23 @@
 FROM node:19.0-buster
+
 WORKDIR /usr/src/app
+
+RUN wget https://dl.google.com/go/go1.19.linux-amd64.tar.gz && tar -xvf go1.19.linux-amd64.tar.gz && mv go /usr/local
+
+ENV GOROOT=/usr/local/go
+ENV GOPATH=$HOME/go
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
 COPY package.json package-lock.json ./
-RUN apk add --no-cache git
+
 RUN npm ci --production
+
 RUN npm cache clean --force
+
 RUN npm install --save-dev smee-client
+
 ENV NODE_ENV="production"
+
 COPY . .
+
 CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM node:12-slim
+FROM node:19.0-buster
 WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
+RUN apk add --no-cache git
 RUN npm ci --production
 RUN npm cache clean --force
 RUN npm install --save-dev smee-client

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "smee-client": "^1.2.2"
   },
   "engines": {
-    "node": ">= 10.13.0"
+    "node": ">= 19.0.0"
   },
   "jest": {
     "testEnvironment": "node"


### PR DESCRIPTION
This PR upgrades the node version to a more recent version. And changes the Docker images from `slim` to `buster`. The slim image did not contain the `git` command (along with a lot of other utilities) which was failing the auto-documentation feature of the vitess-bot.

Additionally, this PR installs the Go library in the docker image.