### PR TITLE
Fix create backport endpoint when PRs are closed instead of merged

### DIFF
--- a/index.js
+++ b/index.js
@@ -254,7 +254,7 @@ This Pull Request updates the error code documentation based on the changes made
   });
 
   app.on(["pull_request.closed"], async (context) => {
-    if (context.payload.merged == false) {
+    if (context.payload.merged !== true) {
       return
     }
 


### PR DESCRIPTION
This PR fixes an issue that happens when the bot tries to backport a Pull Request after closing it. We should not try to backport PRs if they are closed instead of merged.