### PR TITLE
Fix the path taken to go run the error generation script in vitess

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ module.exports = (app) => {
     }
     execSync("git clone https://github.com/vitessio/vitess /tmp/vitess || true");
     execSync("cd /tmp/vitess && git fetch origin refs/pull/" + pr.pull_number + "/head && git checkout FETCH_HEAD");
-    let output = execSync("cd /tmp/vitess && go run ./go/vt/vterrors/main/");
+    let output = execSync("cd /tmp/vitess && go run .go/vt/vterrors/vterrorsgen/");
     let errStrVitess = output.toString()
 
     const docPath = "/tmp/website/content/en/docs/15.0/reference/errors/query-serving.md"


### PR DESCRIPTION
This PR changes the path used to run the error generation script in Vitess. The path of the script changed in https://github.com/vitessio/vitess/pull/10738.