### PR TITLE
Generate error documentation based on the incoming release branch

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,18 @@ module.exports = (app) => {
     let output = execSync("cd /tmp/vitess && go run ./go/vt/vterrors/vterrorsgen");
     let errStrVitess = output.toString()
 
-    const docPath = "/tmp/website/content/en/docs/15.0/reference/errors/query-serving.md"
+    const pr_details = await context.octokit.rest.pulls.get({
+      owner: pr.owner,
+      repo: pr.repo,
+      pull_number: pr.pull_number,
+    });
+
+    let currVersion = "16.0";
+    if (pr_details.data.base.ref.startsWith("release-") && pr_details.data.base.ref.length == "release-00.0".length) {
+      currVersion = pr_details.data.base.ref.slice("release-".length)
+    }
+
+    const docPath = "/tmp/website/content/en/docs/" + currVersion + "/reference/errors/query-serving.md"
     execSync("git clone https://github.com/vitessio/website /tmp/website || true");
     execSync("cd /tmp/website");
     output = execSync("cd /tmp/website && git fetch && cat " + docPath);

--- a/index.js
+++ b/index.js
@@ -136,15 +136,16 @@ module.exports = (app) => {
       pull_number: pr.pull_number,
     });
 
-    let currVersion = "16.0";
+    execSync("git clone https://github.com/vitessio/website /tmp/website || true");
+    output = execSync(`cd /tmp/website && cat config.toml | grep next | cut -d '"' -f 2`);
+
+    let currVersion = output.toString();
     if (pr_details.data.base.ref.startsWith("release-") && pr_details.data.base.ref.length == "release-00.0".length) {
       currVersion = pr_details.data.base.ref.slice("release-".length)
     }
-
     const docPath = "/tmp/website/content/en/docs/" + currVersion + "/reference/errors/query-serving.md"
-    execSync("git clone https://github.com/vitessio/website /tmp/website || true");
-    execSync("cd /tmp/website");
-    output = execSync("cd /tmp/website && git fetch && cat " + docPath);
+
+    output = execSync("cd /tmp/website && cat " + docPath);
     let errStrWebsite = output.toString()
 
     const prefixLabel = "<!-- start -->"


### PR DESCRIPTION
## Description

This PR changes how we generate the query serving error documentation. The documentation will now be placed in the proper release documentation folder. By default the folder will be on `16.0`, and if the base of the Pull Request is a release branch, we parse the output version folder from the branch name.