### PR TITLE
Add `Needs...` labels to PR on creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,21 @@ This is a ` + type + ` of #` + pr.pull_number + `.
 
 module.exports = (app) => {
 
+  app.on(["pull_request.opened"], async (context) => {
+    const pr = context.pullRequest();
+
+    if (pr.owner != 'vitessio' || pr.repo != 'vitess') {
+      return
+    }
+
+    await context.octokit.rest.issues.addLabels({
+      owner: pr.owner,
+      repo: pr.repo,
+      issue_number: pr.pull_number,
+      labels: ["NeedsWebsiteDocsUpdate", "NeedsDescriptionUpdate"],
+    });
+  })
+
   app.on(["pull_request.opened", "pull_request.synchronize"], async (context) => {
     const pr = context.pullRequest();
 


### PR DESCRIPTION
This PR is a follow up of the work done in https://github.com/vitessio/vitess/pull/12062 and applies what was suggested in https://github.com/vitessio/vitess/pull/12062#pullrequestreview-1242731959.

When a PR is created, the bot will automatically add the `NeedsWebsiteDocsUpdate` and `NeedsDescriptionUpdate` labels to the PR. An example is available here: https://github.com/vitessio/vitess/pull/12078.