### PR TITLE
handler workdirs

### DIFF
--- a/go/git/branch.go
+++ b/go/git/branch.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package git
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/go-github/v53/github"
+)
+
+// CreateBranch uses the github client to create a branch with the provided name
+// and based on the provided ref in this repository.
+func (r *Repo) CreateBranch(ctx context.Context, client *github.Client, base *github.Reference, name string) (ref *github.Reference, err error) {
+	ref = &github.Reference{
+		Ref: github.String("refs/heads/" + name),
+		Object: &github.GitObject{
+			SHA: base.GetObject().SHA,
+		},
+	}
+
+	_, _, err = client.Git.CreateRef(ctx, r.Owner, r.Name, ref)
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		return nil, err
+	}
+
+	return ref, nil
+}

--- a/go/git/repo.go
+++ b/go/git/repo.go
@@ -143,5 +143,5 @@ func (r *Repo) ResetHard(ctx context.Context, ref string) error {
 }
 
 func (r *Repo) Status(ctx context.Context, arg ...string) ([]byte, error) {
-	return shell.NewContext(ctx, "git", append([]string{"status"}, arg...)...).InDir("/tmp/website").Output()
+	return shell.NewContext(ctx, "git", append([]string{"status"}, arg...)...).InDir(r.LocalDir).Output()
 }

--- a/go/main.go
+++ b/go/main.go
@@ -62,9 +62,9 @@ func main() {
 		panic(err)
 	}
 
-	prCommentHandler := &PullRequestHandler{
-		ClientCreator:   cc,
-		reviewChecklist: cfg.reviewChecklist,
+	prCommentHandler, err := NewPullRequestHandler(cc, cfg.reviewChecklist)
+	if err != nil {
+		panic(err)
 	}
 
 	webhookHandler := githubapp.NewEventDispatcher(

--- a/go/porting.go
+++ b/go/porting.go
@@ -76,15 +76,8 @@ func cherryPickAndPortPR(
 
 	// Create a new branch from the release branch
 	newBranch := fmt.Sprintf("%s-%d-to-%s", portType, originalPR.GetNumber(), branch)
-	newRef := &github.Reference{
-		Ref: github.String("refs/heads/" + newBranch),
-		Object: &github.GitObject{
-			SHA: releaseRef.GetObject().SHA,
-		},
-	}
-
-	_, _, err = client.Git.CreateRef(ctx, originalPRInfo.repoOwner, originalPRInfo.repoName, newRef)
-	if err != nil && !strings.Contains(err.Error(), "already exists") {
+	_, err = repo.CreateBranch(ctx, client, releaseRef, newBranch)
+	if err != nil {
 		return nil, false, errors.Wrapf(err, "Failed to create git ref %s on repository %s/%s to backport Pull Request %d", newBranch, originalPRInfo.repoOwner, originalPRInfo.repoName, originalPRInfo.num)
 	}
 

--- a/go/shell/shell.go
+++ b/go/shell/shell.go
@@ -19,6 +19,7 @@ package shell
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 )
 
@@ -54,6 +55,10 @@ func (c *cmd) WithEnv(env ...string) *cmd {
 //
 // Must be called before running the command.
 func (c *cmd) WithExtraEnv(env ...string) *cmd {
+	if c.Env == nil {
+		c.Env = os.Environ()
+	}
+
 	c.Env = append(c.Env, env...)
 	return c
 }


### PR DESCRIPTION
to merge after #58

This gives handlers dedicated working directories
    
this is in advance of the introduction of a second handler for releases,
and this will allow the two handlers to manage their own repo locks,
checkouts, parallelization, etc.

seems to work ok: https://github.com/ajm188/website/pull/7 via https://github.com/ajm188/vitess/pull/8