### PR TITLE
cobradocs preview

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -62,7 +62,7 @@ func main() {
 		panic(err)
 	}
 
-	prCommentHandler, err := NewPullRequestHandler(cc, cfg.reviewChecklist)
+	prCommentHandler, err := NewPullRequestHandler(cc, cfg.reviewChecklist, cfg.botLogin)
 	if err != nil {
 		panic(err)
 	}

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -52,15 +52,17 @@ var (
 type PullRequestHandler struct {
 	githubapp.ClientCreator
 
+	botLogin        string
 	reviewChecklist string
 
 	vitessRepoLock  sync.Mutex
 	websiteRepoLock sync.Mutex
 }
 
-func NewPullRequestHandler(cc githubapp.ClientCreator, reviewChecklist string) (h *PullRequestHandler, err error) {
+func NewPullRequestHandler(cc githubapp.ClientCreator, reviewChecklist, botLogin string) (h *PullRequestHandler, err error) {
 	h = &PullRequestHandler{
 		ClientCreator:   cc,
+		botLogin:        botLogin,
 		reviewChecklist: reviewChecklist,
 	}
 	err = os.MkdirAll(h.Workdir(), 0777|os.ModeDir)

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -568,7 +568,13 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 		return nil, errors.Wrapf(err, "Failed to run cobradocs sync script against %s:%s to %s for %s", remote, ref, op, pr.GetHTMLURL())
 	}
 
-	// TODO: do we need to amend the commit to change the author to the bot?
+	// Amend the commit to change the author to the bot.
+	if err := website.Commit(ctx, fmt.Sprintf("generate cobradocs against %s:%s", remote, ref), git.CommitOpts{
+		Author: botCommitAuthor,
+		Amend:  true,
+	}); err != nil {
+		return nil, errors.Wrapf(err, "Failed to amend commit author to %s for %s", op, pr.GetHTMLURL())
+	}
 
 	// 4. Switch vitess repo to the PR's head ref.
 	ref = pr.GetHead().GetRef()
@@ -590,7 +596,13 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 		return nil, errors.Wrapf(err, "Failed to run cobradocs sync script against %s/%s:%s to %s for %s", vitess.Owner, vitess.Name, ref, op, pr.GetHTMLURL())
 	}
 
-	// TODO: do we need to amend the commit to change the author to the bot?
+	// Amend the commit to change the author to the bot.
+	if err := website.Commit(ctx, fmt.Sprintf("generate cobradocs against %s/%s:%s", website.Owner, website.Name, ref), git.CommitOpts{
+		Author: botCommitAuthor,
+		Amend:  true,
+	}); err != nil {
+		return nil, errors.Wrapf(err, "Failed to amend commit author to %s for %s", op, pr.GetHTMLURL())
+	}
 
 	// 6. Force push.
 	if err := website.Push(ctx, git.PushOpts{


### PR DESCRIPTION
Based on #60 to merge afterwards.

This adds functionality to preview cobradoc changes

This occurs on PRs opened against either the `main` branch or `release-`
branches. The strategy here is to always have the PR consist of two
commits; the first commit is the docs generated against the base ref of
the PR, and the second commit is the docs generated against the head ref
of the PR. It's possible, but unlikely, that the first commit will be
empty, but the second commit will always contain a diff. These preview PRs
should never be merged, anyway.

See https://github.com/ajm188/website/pull/14 and https://github.com/ajm188/website/pull/15 for some demonstrations