### PR TITLE
Checkout FETCH_HEAD, not HEAD when setting up repos for cobradocs sync

### DIFF
--- a/go/cobradocs_sync.go
+++ b/go/cobradocs_sync.go
@@ -132,7 +132,7 @@ func setupRepo(ctx context.Context, repo *git.Repo, op string) error {
 		return errors.Wrapf(err, "Failed to fetch origin on repository %s/%s to %s", repo.Owner, repo.Name, op)
 	}
 
-	if err := repo.ResetHard(ctx, "HEAD"); err != nil {
+	if err := repo.ResetHard(ctx, "FETCH_HEAD"); err != nil {
 		return errors.Wrapf(err, "Failed to reset the repository %s/%s to %s", repo.Owner, repo.Name, op)
 	}
 

--- a/go/cobradocs_sync.go
+++ b/go/cobradocs_sync.go
@@ -124,6 +124,10 @@ func setupRepo(ctx context.Context, repo *git.Repo, op string) error {
 		return errors.Wrapf(err, "Failed to clean the repository %s/%s to %s", repo.Owner, repo.Name, op)
 	}
 
+	if err := repo.Checkout(ctx, repo.DefaultBranch); err != nil {
+		return errors.Wrapf(err, "Failed to checkout %s in %s/%s to %s", repo.DefaultBranch, repo.Owner, repo.Name, op)
+	}
+
 	if err := repo.Fetch(ctx, "origin"); err != nil {
 		return errors.Wrapf(err, "Failed to fetch origin on repository %s/%s to %s", repo.Owner, repo.Name, op)
 	}

--- a/go/git/repo.go
+++ b/go/git/repo.go
@@ -25,20 +25,27 @@ import (
 )
 
 type Repo struct {
-	Owner    string
-	Name     string
-	LocalDir string
+	Owner         string
+	Name          string
+	DefaultBranch string
+	LocalDir      string
 }
 
 func NewRepo(owner, name string) *Repo {
 	return &Repo{
-		Owner: owner,
-		Name:  name,
+		Owner:         owner,
+		Name:          name,
+		DefaultBranch: "main",
 	}
 }
 
 func (r *Repo) WithLocalDir(dir string) *Repo {
 	r.LocalDir = dir
+	return r
+}
+
+func (r *Repo) WithDefaultBranch(branch string) *Repo {
+	r.DefaultBranch = branch
 	return r
 }
 

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -513,7 +513,9 @@ func (h *PullRequestHandler) previewCobraDocs(ctx context.Context, event github.
 	website := git.NewRepo(
 		prInfo.repoOwner,
 		"website",
-	).WithLocalDir(filepath.Join(h.Workdir(), "website"))
+	).WithDefaultBranch("prod").WithLocalDir(
+		filepath.Join(h.Workdir(), "website"),
+	)
 
 	_, err = h.createCobraDocsPreviewPR(ctx, client, vitess, website, event.GetPullRequest(), docsVersion, prInfo)
 	return err


### PR DESCRIPTION
Compare https://github.com/vitessio/vitess-bot/blob/main/go/documentation_generation.go#L66 vs https://github.com/vitessio/vitess-bot/blob/main/go/cobradocs_sync.go#L131

The issue here is effectively never `pull` after the first clone, which is (I think) why sync PRs havent' been properly generated.