### PR TITLE
Run `find` in a cross-platform manner

### DIFF
--- a/go/shell/shell.go
+++ b/go/shell/shell.go
@@ -25,6 +25,11 @@ import (
 
 type cmd exec.Cmd
 
+var (
+	globalRegexpOpt string
+	regexpTypeOpt   []string
+)
+
 // New returns a new command can be run.
 func New(name string, arg ...string) *cmd {
 	return NewContext(context.Background(), name, arg...)
@@ -33,6 +38,21 @@ func New(name string, arg ...string) *cmd {
 // NewContext returns a new command that can be run with the given context.
 func NewContext(ctx context.Context, name string, arg ...string) *cmd {
 	return (*cmd)(exec.CommandContext(ctx, name, arg...))
+}
+
+// FindRegexpExtended returns a slice of arguments for doing a `find` command
+// using extended regular expressions in a cross-platform-friendly manner.
+func FindRegexpExtended(path string, expressions ...string) (args []string) {
+	args = []string{path}
+	if globalRegexpOpt != "" {
+		args = []string{globalRegexpOpt, path}
+	}
+
+	if len(regexpTypeOpt) > 0 {
+		args = append(args, regexpTypeOpt...)
+	}
+
+	return append(args, expressions...)
 }
 
 // InDir updates the working directory of the command and returns it.

--- a/go/shell/shell_darwin.go
+++ b/go/shell/shell_darwin.go
@@ -1,0 +1,7 @@
+//go:build darwin
+
+package shell
+
+func init() {
+	globalRegexpOpt = "-E"
+}

--- a/go/shell/shell_unix.go
+++ b/go/shell/shell_unix.go
@@ -1,0 +1,11 @@
+//go:build unix && !darwin
+
+package shell
+
+func init() {
+	regexpTypeOpt = []string{
+		// This is not a typo. It is "regexp" in goland and "regex" in POSIX land. ¯\_(ツ)_/¯
+		"-regextype",
+		"posix-extended",
+	}
+}


### PR DESCRIPTION
Managed to finally get my hands on a relevant log entry and saw:

```
{"level":"error","github_event_type":"pull_request","github_delivery_id":"<omitted>","error":"Failed to `find` latest docs version to generate cobradocs preview for https://github.com/vitessio/vitess/pull/14789: exit status 1\nstderr: find: unknown predicate `-sE'\n\nstdout: ","time":"2024-01-24T13:13:22Z","message":"Unexpected error handling webhook"}
```

So, we need to remove `-sE` on unix, but not on darwin.

`-E` _before_ the path is replaced by `-regextype posix-extended` _after_ the path.

There is no replacement for `-s` on non-darwin unix, so we now need to pipe to `sort` to sort in dictionary order.

---

Tested running this on both my laptop:

```
➜  vtwebsite git:(cross-platform-find) ✗ bash -c "find -E content/en/docs -maxdepth 1 -type d -regex '.*/[0-9]+.[0-9]+' | sort -d"
content/en/docs/16.0
content/en/docs/17.0
content/en/docs/18.0
content/en/docs/19.0
```

And on the bot:

```
vitess-bot:website# bash -c "find content/en/docs -regextype posix-extended -maxdepth 1 -type d -regex '.*/[0-9]+.[0-9]+' | sort -d"
content/en/docs/16.0
content/en/docs/17.0
content/en/docs/18.0
content/en/docs/19.0
```

I _believe_ this will fix https://github.com/vitessio/vitess-bot/issues/63 but I will close manually after verifying.