### PR TITLE
Fetch by PR number rather than ref

### DIFF
--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -609,8 +609,8 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 
 	remote := pr.GetBase().GetRepo().GetCloneURL()
 	ref := pr.GetBase().GetRef()
-	if err := vitess.FetchRef(ctx, remote, ref); err != nil {
-		return nil, errors.Wrapf(err, "Failed to fetch %s:%s to %s for %s", remote, ref, op, pr.GetHTMLURL())
+	if err := vitess.FetchRef(ctx, "origin", fmt.Sprintf("refs/pull/%d/head", pr.GetNumber())); err != nil {
+		return nil, errors.Wrapf(err, "Failed to fetch Pull Request %s/%s#%d to %s for %s", vitess.Owner, vitess.Name, pr.GetNumber(), op, pr.GetHTMLURL())
 	}
 
 	if err := vitess.Checkout(ctx, "FETCH_HEAD"); err != nil {


### PR DESCRIPTION
This is how `cloneVitessAndGenerateErrors` clones; the advantage here is when the PR is based on a branch of a remote _other_ than the repo the PR is against (e.g. `planetscale/vitess` vs `vitessio/vitess`), we can fetch the PR's `HEAD` without needing to add a remote for that repository.

Didn't come up in my local testing as I was opening PRs against the same repo (`ajm188/vitess`).

See https://github.com/vitessio/vitess-bot/blob/main/go/documentation_generation.go#L62 for ex