### PR TITLE
Use GitHub API for push operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/bradleyfalzon/ghinstallation/v2 v2.5.0 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
@@ -23,12 +24,16 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shurcooL/githubv4 v0.0.0-20230424031643-6cea62ecd5a9 // indirect
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	golang.org/x/crypto v0.10.0 // indirect
 	golang.org/x/net v0.11.0 // indirect
 	golang.org/x/oauth2 v0.9.0 // indirect
 	golang.org/x/sys v0.9.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,9 @@ github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtM
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
@@ -42,6 +45,8 @@ github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaR
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
@@ -51,6 +56,14 @@ github.com/shurcooL/githubv4 v0.0.0-20230424031643-6cea62ecd5a9 h1:nCBaIs5/R0HFP
 github.com/shurcooL/githubv4 v0.0.0-20230424031643-6cea62ecd5a9/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
 github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f h1:tygelZueB1EtXkPI6mQ4o9DQ0+FKW41hTbunoXZCTqk=
 github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -117,3 +130,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/git/diff_tree.go
+++ b/go/git/diff_tree.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package git
 
 import (

--- a/go/git/diff_tree.go
+++ b/go/git/diff_tree.go
@@ -26,14 +26,18 @@ import (
 )
 
 /*
+Example output of `git diff-tree -r HEAD~1 HEAD` in a sample repo:
+
 :100644 000000 5716ca5987cbf97d6bb54920bea6adde242d87e6 0000000000000000000000000000000000000000 D	bar/bar.txt
 :000000 100644 0000000000000000000000000000000000000000 76018072e09c5d31c8c6e3113b8aa0fe625195ca A	baz.txt
 :100644 100644 257cc5642cb1a054f08cc83f2d943e56fd3ebe99 b210800439ffe3f2db0d47d9aab1969b38a770a5 M	foo.txt
 */
-
 var diffTreeEntryRegexp = regexp.MustCompile(`^:(?P<oldmode>\d{6}) (?P<newmode>\d{6}) (?P<oldsha>[a-f0-9]{40}) (?P<newsha>[a-f0-9]{40}) [A-Z]\W(?P<path>.*)$`)
 
-// See https://docs.github.com/en/rest/git/trees?apiVersion=2022-11-28#create-a-tree
+// ParseDiffTreeEntry parses a single line from `git diff-tree A B` into a
+// TreeEntry object suitable to pass to github's CreateTree method.
+//
+// See https://docs.github.com/en/rest/git/trees?apiVersion=2022-11-28#create-a-tree.
 func ParseDiffTreeEntry(line string, basedir string) (*github.TreeEntry, error) {
 	match := diffTreeEntryRegexp.FindStringSubmatch(line)
 	if match == nil {

--- a/go/git/diff_tree.go
+++ b/go/git/diff_tree.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -20,7 +21,7 @@ var diffTreeEntryRegexp = regexp.MustCompile(`^:(?P<oldmode>\d{6}) (?P<newmode>\
 func ParseDiffTreeEntry(line string, basedir string) (*github.TreeEntry, error) {
 	match := diffTreeEntryRegexp.FindStringSubmatch(line)
 	if match == nil {
-		return nil, nil
+		return nil, fmt.Errorf("invalid diff-tree line format %s", line)
 	}
 
 	oldMode := match[1]

--- a/go/git/diff_tree.go
+++ b/go/git/diff_tree.go
@@ -1,0 +1,57 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/google/go-github/v53/github"
+)
+
+/*
+:100644 000000 5716ca5987cbf97d6bb54920bea6adde242d87e6 0000000000000000000000000000000000000000 D	bar/bar.txt
+:000000 100644 0000000000000000000000000000000000000000 76018072e09c5d31c8c6e3113b8aa0fe625195ca A	baz.txt
+:100644 100644 257cc5642cb1a054f08cc83f2d943e56fd3ebe99 b210800439ffe3f2db0d47d9aab1969b38a770a5 M	foo.txt
+*/
+
+var diffTreeEntryRegexp = regexp.MustCompile(`^:(?P<oldmode>\d{6}) (?P<newmode>\d{6}) (?P<oldsha>[a-f0-9]{40}) (?P<newsha>[a-f0-9]{40}) [A-Z]\W(?P<path>.*)$`)
+
+// See https://docs.github.com/en/rest/git/trees?apiVersion=2022-11-28#create-a-tree
+func ParseDiffTreeEntry(line string, basedir string) (*github.TreeEntry, *github.Blob, error) {
+	match := diffTreeEntryRegexp.FindStringSubmatch(line)
+	if match == nil {
+		return nil, nil, nil
+	}
+
+	oldMode := match[1]
+	newMode := match[2]
+	// oldSHA := match[3]
+	// newSHA := match[4]
+	path := match[5]
+
+	entry := github.TreeEntry{
+		Path: &path,
+		Mode: &newMode,
+		Type: github.String("blob"),
+	}
+
+	if newMode == "000000" {
+		// File deleted.
+		entry.Mode = &oldMode // GitHub API suggests sending 000000 will result in an error, and we're deleting the file anyway.
+		entry.SHA = nil
+
+		return &entry, nil, nil
+	}
+
+	content, err := os.ReadFile(filepath.Join(basedir, path))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	entry.Content = github.String(string(content))
+
+	return &entry, &github.Blob{
+		Content:  entry.Content,
+		Encoding: github.String("utf-8"),
+	}, nil
+}

--- a/go/git/diff_tree.go
+++ b/go/git/diff_tree.go
@@ -17,10 +17,10 @@ import (
 var diffTreeEntryRegexp = regexp.MustCompile(`^:(?P<oldmode>\d{6}) (?P<newmode>\d{6}) (?P<oldsha>[a-f0-9]{40}) (?P<newsha>[a-f0-9]{40}) [A-Z]\W(?P<path>.*)$`)
 
 // See https://docs.github.com/en/rest/git/trees?apiVersion=2022-11-28#create-a-tree
-func ParseDiffTreeEntry(line string, basedir string) (*github.TreeEntry, *github.Blob, error) {
+func ParseDiffTreeEntry(line string, basedir string) (*github.TreeEntry, error) {
 	match := diffTreeEntryRegexp.FindStringSubmatch(line)
 	if match == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	oldMode := match[1]
@@ -40,18 +40,15 @@ func ParseDiffTreeEntry(line string, basedir string) (*github.TreeEntry, *github
 		entry.Mode = &oldMode // GitHub API suggests sending 000000 will result in an error, and we're deleting the file anyway.
 		entry.SHA = nil
 
-		return &entry, nil, nil
+		return &entry, nil
 	}
 
 	content, err := os.ReadFile(filepath.Join(basedir, path))
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	entry.Content = github.String(string(content))
 
-	return &entry, &github.Blob{
-		Content:  entry.Content,
-		Encoding: github.String("utf-8"),
-	}, nil
+	return &entry, nil
 }

--- a/go/git/diff_tree.go
+++ b/go/git/diff_tree.go
@@ -46,8 +46,6 @@ func ParseDiffTreeEntry(line string, basedir string) (*github.TreeEntry, error) 
 
 	oldMode := match[1]
 	newMode := match[2]
-	// oldSHA := match[3]
-	// newSHA := match[4]
 	path := match[5]
 
 	entry := github.TreeEntry{

--- a/go/git/diff_tree_test.go
+++ b/go/git/diff_tree_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package git
 
 import (

--- a/go/git/diff_tree_test.go
+++ b/go/git/diff_tree_test.go
@@ -17,15 +17,20 @@ limitations under the License.
 package git
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-github/v53/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseDiffTreeEntry(t *testing.T) {
-	// TODO: create fake filesystem
-	// baz.txt contains: baz
-	// foo.txt contains foo\nfoo2 after the edit
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "baz.txt"), []byte("baz"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "foo.txt"), []byte("foo"), 0644))
+
 	tcases := []struct {
 		name    string
 		in      string
@@ -62,15 +67,25 @@ func TestParseDiffTreeEntry(t *testing.T) {
 				Content: github.String("foo"),
 			},
 		},
+		{
+			name:    "empty line",
+			in:      "",
+			want:    nil,
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			// entry, err := ParseDiffTreeEntry(tc.in, "TODO")
+			entry, err := ParseDiffTreeEntry(tc.in, tmp)
 			if tc.wantErr {
-				// TODO:
+				assert.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, entry)
 		})
 	}
 }

--- a/go/git/diff_tree_test.go
+++ b/go/git/diff_tree_test.go
@@ -1,0 +1,60 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v53/github"
+)
+
+func TestParseDiffTreeEntry(t *testing.T) {
+	// TODO: create fake filesystem
+	// baz.txt contains: baz
+	// foo.txt contains foo\nfoo2 after the edit
+	tcases := []struct {
+		name    string
+		in      string
+		want    *github.TreeEntry
+		wantErr bool
+	}{
+		{
+			name: "deleted file",
+			in:   ":100644 000000 5716ca5987cbf97d6bb54920bea6adde242d87e6 0000000000000000000000000000000000000000 D	bar/bar.txt",
+			want: &github.TreeEntry{
+				SHA:  nil, // Indicates deletion
+				Path: github.String("bar/bar.txt"),
+				Mode: github.String("100644"),
+				Type: github.String("blob"),
+			},
+		},
+		{
+			name: "created file",
+			in:   ":000000 100644 0000000000000000000000000000000000000000 76018072e09c5d31c8c6e3113b8aa0fe625195ca A	baz.txt",
+			want: &github.TreeEntry{
+				Path:    github.String("baz.txt"),
+				Mode:    github.String("100644"),
+				Type:    github.String("blob"),
+				Content: github.String("baz"),
+			},
+		},
+		{
+			name: "modified file",
+			in:   ":100644 100644 257cc5642cb1a054f08cc83f2d943e56fd3ebe99 b210800439ffe3f2db0d47d9aab1969b38a770a5 M	foo.txt",
+			want: &github.TreeEntry{
+				Path:    github.String("foo.txt"),
+				Mode:    github.String("100644"),
+				Type:    github.String("blob"),
+				Content: github.String("foo"),
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// entry, err := ParseDiffTreeEntry(tc.in, "TODO")
+			if tc.wantErr {
+				// TODO:
+			}
+		})
+	}
+}

--- a/go/git/repo.go
+++ b/go/git/repo.go
@@ -120,7 +120,7 @@ func (r *Repo) DiffTree(ctx context.Context, baseTreeIsh string, headTreeIsh str
 
 	args = append(args, baseTreeIsh, headTreeIsh)
 
-	return shell.NewContext(ctx, "git", args...).Output()
+	return shell.NewContext(ctx, "git", args...).InDir(r.LocalDir).Output()
 }
 
 func (r *Repo) Fetch(ctx context.Context, remote string) error {

--- a/go/git/repo.go
+++ b/go/git/repo.go
@@ -108,6 +108,21 @@ func (r *Repo) Commit(ctx context.Context, msg string, opts CommitOpts) error {
 	return err
 }
 
+type DiffTreeOpts struct {
+	Recursive bool
+}
+
+func (r *Repo) DiffTree(ctx context.Context, baseTreeIsh string, headTreeIsh string, opts DiffTreeOpts) ([]byte, error) {
+	args := []string{"diff-tree"}
+	if opts.Recursive {
+		args = append(args, "-r")
+	}
+
+	args = append(args, baseTreeIsh, headTreeIsh)
+
+	return shell.NewContext(ctx, "git", args...).Output()
+}
+
 func (r *Repo) Fetch(ctx context.Context, remote string) error {
 	return r.fetch(ctx, remote)
 }

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -780,7 +780,7 @@ func (h *PullRequestHandler) writeAndCommitTree(
 			continue
 		}
 
-		entry, _, err := git.ParseDiffTreeEntry(string(line), repo.LocalDir)
+		entry, err := git.ParseDiffTreeEntry(string(line), repo.LocalDir)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "Failed to parse diff-tree entry to %s for %s", op, pr.GetHTMLURL())
 		}
@@ -789,15 +789,6 @@ func (h *PullRequestHandler) writeAndCommitTree(
 			logger.Debug().Msgf("Invalid diff-tree line %s", line)
 			continue
 		}
-
-		// 		if blob != nil {
-		// 			logger.Debug().Msgf("Creating blob for %s", entry.GetPath())
-		//
-		// 			_, _, err = client.Git.CreateBlob(ctx, repo.Owner, repo.Name, blob)
-		// 			if err != nil {
-		// 				return nil, nil, errors.Wrapf(err, "Failed to create blob for %s to %s for %s", entry.GetPath(), op, pr.GetHTMLURL())
-		// 			}
-		// 		}
 
 		tree.Entries = append(tree.Entries, entry)
 	}

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -798,6 +798,7 @@ func (h *PullRequestHandler) writeAndCommitTree(
 		tree.Entries = append(tree.Entries, entry)
 	}
 
+	logger.Debug().Msgf("Creating tree with %d entries based on %s", len(tree.Entries), baseTree)
 	tree, _, err = client.Git.CreateTree(ctx, repo.Owner, repo.Name, baseTree, tree.Entries)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "Failed to create tree based on %s to %s for %s", baseTree, op, pr.GetHTMLURL())
@@ -810,6 +811,7 @@ func (h *PullRequestHandler) writeAndCommitTree(
 			{SHA: &parentCommit},
 		},
 	}
+	logger.Debug().Msgf("Authoring commit %q with tree %s with parent %s", commitMsg, tree.GetSHA(), parentCommit)
 	commit, _, err = client.Git.CreateCommit(ctx, repo.Owner, repo.Name, commit)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "Failed to create commit based on %s to %s for %s", parentCommit, op, pr.GetHTMLURL())

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -549,6 +549,10 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 	op := "generate cobradocs preview"
 	var openPR *github.PullRequest
 
+	if err := website.FetchRef(ctx, "origin", branch); err != nil {
+		return nil, errors.Wrapf(err, "Failed to fetch origin/%s in %s/%s to %s for %s", branch, website.Owner, website.Name, op, pr.GetHTMLURL())
+	}
+
 	if err := createAndCheckoutBranch(ctx, client, website, branch, headBranch, fmt.Sprintf("%s for %s", op, pr.GetHTMLURL())); err != nil {
 		return nil, err
 	}
@@ -642,7 +646,7 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 		client,
 		website,
 		pr,
-		"prod",
+		branch,
 		"HEAD",
 		baseTree,
 		parent,

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -696,7 +696,7 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 		"HEAD",
 		tree.GetSHA(),
 		commit.GetSHA(),
-		fmt.Sprintf("Generate cobradocs after preview against %s:%s", remote, ref),
+		fmt.Sprintf("Generate cobradocs after preview against %s:%s", remote, pr.GetHead().GetRef()),
 		op,
 	)
 	if err != nil {
@@ -723,10 +723,10 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 		// 7. Create PR with clear instructions that this is for preview purposes only
 		// and must not be merged.
 		newPR := &github.NewPullRequest{
-			Title:               github.String(fmt.Sprintf("[DO NOT MERGE] [cobradocs] preview cobradocs changes for %s/%s:%s", vitess.Owner, vitess.Name, ref)),
+			Title:               github.String(fmt.Sprintf("[DO NOT MERGE] [cobradocs] preview cobradocs changes for %s/%s#%d", vitess.Owner, vitess.Name, prInfo.num)),
 			Head:                github.String(headBranch),
 			Base:                github.String(branch),
-			Body:                github.String(fmt.Sprintf("## Description\nThis is an automated PR to update the released cobradocs with [%s/%s:%s](%s)", vitess.Owner, vitess.Name, ref, pr.GetHTMLURL())),
+			Body:                github.String(fmt.Sprintf("## Description\nThis is an automated PR to preview changes to the the released cobradocs with %s", pr.GetHTMLURL())),
 			MaintainerCanModify: github.Bool(true),
 		}
 		openPR, _, err = client.PullRequests.Create(ctx, website.Owner, website.Name, newPR)

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -653,14 +653,6 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 		return nil, err
 	}
 
-	// // Amend the commit to change the author to the bot.
-	// if err := website.Commit(ctx, fmt.Sprintf("generate cobradocs against %s:%s", remote, ref), git.CommitOpts{
-	// 	Author: botCommitAuthor,
-	// 	Amend:  true,
-	// }); err != nil {
-	// 	return nil, errors.Wrapf(err, "Failed to amend commit author to %s for %s", op, pr.GetHTMLURL())
-	// }
-
 	// 4. Switch vitess repo to the PR's head ref.
 	if err := vitess.FetchRef(ctx, remote, fmt.Sprintf("refs/pull/%d/head", pr.GetNumber())); err != nil {
 		return nil, errors.Wrapf(err, "Failed to fetch Pull Request %s/%s#%d to %s for %s", vitess.Owner, vitess.Name, pr.GetNumber(), op, pr.GetHTMLURL())
@@ -677,14 +669,6 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 	).Output()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to run cobradocs sync script against %s/%s:%s to %s for %s", vitess.Owner, vitess.Name, ref, op, pr.GetHTMLURL())
-	}
-
-	// Amend the commit to change the author to the bot.
-	if err := website.Commit(ctx, fmt.Sprintf("generate cobradocs against %s/%s:%s", website.Owner, website.Name, ref), git.CommitOpts{
-		Author: botCommitAuthor,
-		Amend:  true,
-	}); err != nil {
-		return nil, errors.Wrapf(err, "Failed to amend commit author to %s for %s", op, pr.GetHTMLURL())
 	}
 
 	_, commit, err = h.writeAndCommitTree(
@@ -708,15 +692,6 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 		Ref:    &headRef,
 		Object: &github.GitObject{SHA: commit.SHA},
 	}, true)
-	//
-	// 	// 6. Force push.
-	// 	if err := website.Push(ctx, git.PushOpts{
-	// 		Remote: "origin",
-	// 		Refs:   []string{headBranch},
-	// 		Force:  true,
-	// 	}); err != nil {
-	// 		return nil, errors.Wrapf(err, "Failed to push %s to %s for %s", headBranch, op, pr.GetHTMLURL())
-	// 	}
 
 	switch openPR {
 	case nil:

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -776,7 +776,11 @@ func (h *PullRequestHandler) writeAndCommitTree(
 	var tree = &github.Tree{}
 
 	for _, line := range lines {
-		entry, blob, err := git.ParseDiffTreeEntry(string(line), repo.LocalDir)
+		if len(line) == 0 {
+			continue
+		}
+
+		entry, _, err := git.ParseDiffTreeEntry(string(line), repo.LocalDir)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "Failed to parse diff-tree entry to %s for %s", op, pr.GetHTMLURL())
 		}
@@ -786,14 +790,14 @@ func (h *PullRequestHandler) writeAndCommitTree(
 			continue
 		}
 
-		if blob != nil {
-			logger.Debug().Msgf("Creating blob for %s", entry.GetPath())
-
-			_, _, err = client.Git.CreateBlob(ctx, repo.Owner, repo.Name, blob)
-			if err != nil {
-				return nil, nil, errors.Wrapf(err, "Failed to create blob for %s to %s for %s", entry.GetPath(), op, pr.GetHTMLURL())
-			}
-		}
+		// 		if blob != nil {
+		// 			logger.Debug().Msgf("Creating blob for %s", entry.GetPath())
+		//
+		// 			_, _, err = client.Git.CreateBlob(ctx, repo.Owner, repo.Name, blob)
+		// 			if err != nil {
+		// 				return nil, nil, errors.Wrapf(err, "Failed to create blob for %s to %s for %s", entry.GetPath(), op, pr.GetHTMLURL())
+		// 			}
+		// 		}
 
 		tree.Entries = append(tree.Entries, entry)
 	}

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -781,7 +781,14 @@ func (h *PullRequestHandler) writeAndCommitTree(
 			return nil, nil, errors.Wrapf(err, "Failed to parse diff-tree entry to %s for %s", op, pr.GetHTMLURL())
 		}
 
+		if entry == nil {
+			logger.Debug().Msgf("Invalid diff-tree line %s", line)
+			continue
+		}
+
 		if blob != nil {
+			logger.Debug().Msgf("Creating blob for %s", entry.GetPath())
+
 			_, _, err = client.Git.CreateBlob(ctx, repo.Owner, repo.Name, blob)
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "Failed to create blob for %s to %s for %s", entry.GetPath(), op, pr.GetHTMLURL())

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -765,11 +765,6 @@ func (h *PullRequestHandler) writeAndCommitTree(
 			return nil, nil, errors.Wrapf(err, "Failed to parse diff-tree entry to %s for %s", op, pr.GetHTMLURL())
 		}
 
-		if entry == nil {
-			logger.Debug().Msgf("Invalid diff-tree line %s", line)
-			continue
-		}
-
 		tree.Entries = append(tree.Entries, entry)
 	}
 

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -743,15 +743,12 @@ func (h *PullRequestHandler) writeAndCommitTree(
 	commitMsg string,
 	op string,
 ) (*github.Tree, *github.Commit, error) {
-	logger := zerolog.Ctx(ctx)
-
 	out, err := repo.DiffTree(ctx, baseRef, headRef, git.DiffTreeOpts{Recursive: true})
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "Failed to diff-tree %s %s in %s/%s to %s for %s", baseRef, headRef, repo.Owner, repo.Name, op, pr.GetHTMLURL())
 	}
 
 	lines := bytes.Split(out, []byte{'\n'})
-	logger.Debug().Msgf("Found %d entries in diff from %s to %s", len(lines), baseRef, headRef)
 
 	var tree = &github.Tree{}
 
@@ -768,7 +765,6 @@ func (h *PullRequestHandler) writeAndCommitTree(
 		tree.Entries = append(tree.Entries, entry)
 	}
 
-	logger.Debug().Msgf("Creating tree with %d entries based on %s", len(tree.Entries), baseTree)
 	tree, _, err = client.Git.CreateTree(ctx, repo.Owner, repo.Name, baseTree, tree.Entries)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "Failed to create tree based on %s to %s for %s", baseTree, op, pr.GetHTMLURL())
@@ -781,7 +777,7 @@ func (h *PullRequestHandler) writeAndCommitTree(
 			{SHA: &parentCommit},
 		},
 	}
-	logger.Debug().Msgf("Authoring commit %q with tree %s with parent %s", commitMsg, tree.GetSHA(), parentCommit)
+
 	commit, _, err = client.Git.CreateCommit(ctx, repo.Owner, repo.Name, commit)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "Failed to create commit based on %s to %s for %s", parentCommit, op, pr.GetHTMLURL())

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -781,9 +781,11 @@ func (h *PullRequestHandler) writeAndCommitTree(
 			return nil, nil, errors.Wrapf(err, "Failed to parse diff-tree entry to %s for %s", op, pr.GetHTMLURL())
 		}
 
-		_, _, err = client.Git.CreateBlob(ctx, repo.Owner, repo.Name, blob)
-		if err != nil {
-			return nil, nil, errors.Wrapf(err, "Failed to create blob for %s to %s for %s", entry.GetPath(), op, pr.GetHTMLURL())
+		if blob != nil {
+			_, _, err = client.Git.CreateBlob(ctx, repo.Owner, repo.Name, blob)
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "Failed to create blob for %s to %s for %s", entry.GetPath(), op, pr.GetHTMLURL())
+			}
 		}
 
 		tree.Entries = append(tree.Entries, entry)

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -646,7 +646,7 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 		"HEAD",
 		baseTree,
 		parent,
-		fmt.Sprintf("Generate cobradocs before preview against %s:%s", remote, ref),
+		fmt.Sprintf("Generate cobradocs preview against %s:%s", remote, ref),
 		op,
 	)
 	if err != nil {
@@ -680,7 +680,12 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 		"HEAD",
 		tree.GetSHA(),
 		commit.GetSHA(),
-		fmt.Sprintf("Generate cobradocs after preview against %s:%s", remote, pr.GetHead().GetRef()),
+		fmt.Sprintf(
+			"Generate cobradocs preview against %s/%s:%s",
+			pr.GetHead().GetRepo().GetOwner(),
+			pr.GetHead().GetRepo().GetName(),
+			pr.GetHead().GetRef(),
+		),
 		op,
 	)
 	if err != nil {

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -549,10 +549,6 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 	op := "generate cobradocs preview"
 	var openPR *github.PullRequest
 
-	if err := website.FetchRef(ctx, "origin", branch); err != nil {
-		return nil, errors.Wrapf(err, "Failed to fetch origin/%s in %s/%s to %s for %s", branch, website.Owner, website.Name, op, pr.GetHTMLURL())
-	}
-
 	if err := createAndCheckoutBranch(ctx, client, website, branch, headBranch, fmt.Sprintf("%s for %s", op, pr.GetHTMLURL())); err != nil {
 		return nil, err
 	}

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -682,7 +682,7 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 		commit.GetSHA(),
 		fmt.Sprintf(
 			"Generate cobradocs preview against %s/%s:%s",
-			pr.GetHead().GetRepo().GetOwner(),
+			pr.GetHead().GetRepo().GetOwner().GetLogin(),
 			pr.GetHead().GetRepo().GetName(),
 			pr.GetHead().GetRef(),
 		),

--- a/go/shell/shell_darwin.go
+++ b/go/shell/shell_darwin.go
@@ -1,5 +1,21 @@
 //go:build darwin
 
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package shell
 
 func init() {

--- a/go/shell/shell_unix.go
+++ b/go/shell/shell_unix.go
@@ -1,5 +1,21 @@
 //go:build unix && !darwin
 
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package shell
 
 func init() {


### PR DESCRIPTION
Primary change here is replacing `website.Push` with a combination of `client.Git.CreateTree` + `client.Git.CreateCommit` + `client.Git.UpdateRef`, as the latter set of operations uses the authenticated context for our bot as opposed to simply shelling out, which does not have the necessary access.