### PR TITLE
Close doc preview on release merge

### DIFF
--- a/go/cobradocs_sync.go
+++ b/go/cobradocs_sync.go
@@ -29,6 +29,10 @@ import (
 	"github.com/vitess.io/vitess-bot/go/shell"
 )
 
+func cobraDocsSyncBranchName(prNum int) string {
+	return fmt.Sprintf("synchronize-cobradocs-for-%d", prNum)
+}
+
 // synchronize cobradocs from main and release branches
 func (h *PullRequestHandler) synchronizeCobraDocs(
 	ctx context.Context,
@@ -41,7 +45,7 @@ func (h *PullRequestHandler) synchronizeCobraDocs(
 	logger := zerolog.Ctx(ctx)
 	op := "update cobradocs"
 	branch := "prod"
-	headBranch := fmt.Sprintf("synchronize-cobradocs-for-%d", pr.GetNumber())
+	headBranch := cobraDocsSyncBranchName(pr.GetNumber())
 	headRef := fmt.Sprintf("refs/heads/%s", headBranch)
 
 	prodBranch, _, err := client.Repositories.GetBranch(ctx, website.Owner, website.Name, branch, false)

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -643,8 +643,8 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 	).Output()
 	if err != nil {
 		var exitErr *exec.ExitError
-		if (errors.As(err, &exitErr)) &&
-			(bytes.Contains(exitErr.Stderr, []byte("No changes to cobradocs detected"))) {
+		if errors.As(err, &exitErr) &&
+			bytes.Contains(exitErr.Stderr, []byte("No changes to cobradocs detected")) {
 			logger.Info().Msgf("No cobradocs changed for PR %s/%s#%d at base %s. Skipping first commit ...", remote, vitess.Name, pr.GetNumber(), ref)
 			skipFirstCommit = true
 		} else {

--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -537,7 +537,7 @@ func (h *PullRequestHandler) createCobraDocsPreviewPR(
 	// 1. Find an existing PR and switch to its branch, or create a new branch
 	// based on `prod`.
 	branch := "prod"
-	headBranch := fmt.Sprintf("synchronize-cobradocs-for-%d", prInfo.num)
+	headBranch := cobraDocsSyncBranchName(prInfo.num)
 	headRef := fmt.Sprintf("refs/heads/%s", headBranch)
 
 	prodBranch, _, err := client.Repositories.GetBranch(ctx, website.Owner, website.Name, branch, false)

--- a/go/shell/shell.go
+++ b/go/shell/shell.go
@@ -106,9 +106,9 @@ func (c *cmd) Output() ([]byte, error) {
 
 func wrapErr(err error, out []byte) error {
 	if execErr, ok := err.(*exec.ExitError); ok {
-		err := fmt.Errorf("%s\nstderr: %s", err.Error(), execErr.Stderr)
+		err := fmt.Errorf("%w\nstderr: %s", err, execErr.Stderr)
 		if out != nil {
-			err = fmt.Errorf("%s\nstdout: %s", err.Error(), out)
+			err = fmt.Errorf("%w\nstdout: %s", err, out)
 		}
 
 		return err


### PR DESCRIPTION
Tested with https://github.com/ajm188/website/pull/17

Some relevant log lines from the testing:

```
{"level":"info","github_event_type":"pull_request","github_delivery_id":"e6283e60-bf75-11ee-958a-25db88c0abee","github_installation_id":42461852,"github_repository_owner":"ajm188","github_repository_name":"vitess","github_pr_num":14,"time":"2024-01-30T09:54:15-05:00","message":"No cobradocs changed for PR https://github.com/ajm188/vitess.git/vitess#14 at base release-18.0. Skipping first commit ..."}
```

```
{"level":"info","github_event_type":"pull_request","github_delivery_id":"38f51910-bf80-11ee-942a-1075829bfa8d","github_installation_id":42461852,"github_repository_owner":"ajm188","github_repository_name":"vitess","github_pr_num":14,"time":"2024-01-30T09:59:54-05:00","message":"closing open PR ajm188/website#17"}
```

Closes #76 