### PR TITLE
Enhance and optimize the error code generation 

### DIFF
--- a/tools/get_release_from_docs.sh
+++ b/tools/get_release_from_docs.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -euxo pipefail
-
-cat config.toml | grep next | cut -d '"' -f 2 | tr -d '\n'


### PR DESCRIPTION
In this PR I am doing a little refactor of the `PullRequestHandler`'s `Handle` method as it was becoming hard to read. I continued by changing how we detect the version of the docs where we need to update the error code documentation. It used to copy a shell script from the vitess-bot repository into the temporary cloned directory, which lead to keeping stale files on the repository and having to execute shell commands. Moreover, the script we used was not supporting release branches, only main. Meaning that only modification to the error codes on `main` were taken into account, backport to release branches were in some way ignored.