### PR TITLE
Don't sync cobradocs on website

### DIFF
--- a/go/pull_request.go
+++ b/go/pull_request.go
@@ -179,10 +179,6 @@ func (h *PullRequestHandler) closedPullRequest(ctx context.Context, event github
 	if err != nil {
 		return err
 	}
-	err = h.updateDocs(ctx, event, prInfo)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
We are generating a huge number of branches for the cobradocs sync which we don't merge. This PR disables this functionality.