### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
         with:
           go-version: 1.21.5
 
       - name: executing remote ssh commands using password
-        uses: fifsky/ssh-action@master
+        uses: fifsky/ssh-action@5a841de87115730aff750ac127773e3b2b3f56dd
         with:
           host: ${{ secrets.HOST }}
           key: ${{ secrets.KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: 1.21.5
 
       - name: executing remote ssh commands using password
-        uses: fifsky/ssh-action@5a841de87115730aff750ac127773e3b2b3f56dd
+        uses: fifsky/ssh-action@5a841de87115730aff750ac127773e3b2b3f56dd # master
         with:
           host: ${{ secrets.HOST }}
           key: ${{ secrets.KEY }}


### PR DESCRIPTION
## What's this?
Pins the GitHub Actions used by these workflows to the commit SHAs currently targeted by their existing refs.

## How it works
This keeps the same action versions and replaces tag or branch refs with exact SHAs. No action upgrades here.